### PR TITLE
<Input> end removed

### DIFF
--- a/ping.html
+++ b/ping.html
@@ -11,6 +11,6 @@
     </script>
 </head>
 <body>
-    <input id='pingurl' type='text' value='http://google.com'></input>
+    <input id='pingurl' type='text' value='http://google.com'>
     <button onclick='do_ping()'>Ping</button>
 </body>


### PR DESCRIPTION
Usually, the input tag isn't written with an end. It'd probably still work with it, but that'd be because it's being ignored.